### PR TITLE
Fix typo in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Unspoken with Synthizer
-Unspoekn is an add-on which was originally created by Austin Hicks (Camlorn), which plays sounds in 3D to represent controls on the screen rather than speaking control types with speech.
+Unspoken is an add-on which was originally created by Austin Hicks (Camlorn), which plays sounds in 3D to represent controls on the screen rather than speaking control types with speech.
 
 This is a version of Unspoken that works with Python 3 versions of NVDA and uses Synthizer. It works, however be warned of the following:
 


### PR DESCRIPTION
This fixes a case where 'Unspoken' was typed incorrectly.